### PR TITLE
Add socket.data

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -348,6 +348,7 @@ const serialize = (
   return {
     id: socket.id,
     clientId,
+    data: socket.data,
     transport,
     nsp,
     handshake: {

--- a/lib/typed-events.ts
+++ b/lib/typed-events.ts
@@ -24,6 +24,7 @@ interface ServerStats {
 export interface SerializedSocket {
   id: string;
   clientId: string;
+  data: any;
   transport: string;
   nsp: string;
   handshake: any;


### PR DESCRIPTION
# Issue

- https://github.com/socketio/socket.io-admin-ui/issues/32

# Description

Currently doesn't work.

```
Argument of type 
'import("/usr/src/node/node_modules/socket.io/dist/index").Server<import("/usr/src/node/node_modules/socket.io/dist/typed-events").DefaultEventsMap, import("/usr/src/node/node_modules/socket.io/dist/typed-events").DefaultEventsMap, import("/usr/src/node/node_modules/socket.io/dist/typed-events").DefaultEventsMap>' is not assignable to parameter of type 'import("/usr/src/node/admin-ui/socket.io-admin-ui/node_modules/socket.io/dist/index").Server<import("/usr/src/node/admin-ui/socket.io-admin-ui/node_modules/socket.io/dist/typed-events").DefaultEventsMap, import("/usr/src/node/admin-ui/socket.io-admin-ui/node_modules/socket.io/dist/typed-events").DefaultEventsMap, im..
```

I'm assuming it's because socket.io-admin-ui compares typed-event with [socket.io](https://github.com/socketio/socket.io)'s typed-event and they don't match, but if data is not readable on socket.io, I'm probably going about this the wrong way.

@darrachequesne any insight at what I'm doing wrong?

# Details

Currently I'm using the local module by editing my `package.json` like this:

```
  "dependencies": {
    "@socket.io/admin-ui": "file:admin-ui/socket.io-admin-ui", //use your local folder's relative path here
```