### PR TITLE
fix: RedisStore saveSession when set value as string

### DIFF
--- a/lib/stores.ts
+++ b/lib/stores.ts
@@ -65,7 +65,7 @@ export class RedisStore extends Store {
     const key = this.computeKey(sessionId);
     this.redisClient
       .multi()
-      .set(key, true)
+      .set(key, "true")
       .expire(key, this.options.sessionDuration)
       .exec();
   }


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/7059827/230266912-dbb3b748-b5a7-4a9e-bce8-fd2134b32ad9.png)

Issue reference: https://github.com/socketio/socket.io-admin-ui/issues/65