### PR TITLE
feat: Add dockerfile for easier selfhosting.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM nginx:stable-alpine
+WORKDIR /app
+COPY ./ui/dist .
+COPY ./nginx.conf /etc/nginx/nginx.conf 
+RUN command

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,22 @@
+events {
+    worker_connections 1024;
+}
+
+http {
+    include mime.types;
+    sendfile on;
+
+    server {
+        listen 8080;
+        listen [::]:8080;
+
+        resolver 127.0.0.11;
+        autoindex off;
+
+        server_name _;
+        server_tokens off;
+
+        root /app/;
+        gzip_static on;
+    }
+}


### PR DESCRIPTION
Hey, think it would be useful to add a Dockerfile for selfhosting. If there's a better location for them, please let me know. I can also make a PR for a github action to build and push this image.

I'm just using a basic nginx:stable-alpine image and a nginx.conf that serves /app inside of the container. If this isn't needed, you want documentation added for easy building/launching, or those actions please @ me.

To test it out run:
```bash
docker build -t test .
docker run -d -p 8080:8080 test
``` 

Then it should be accessible at port 8080 in your browser on whatever machine you're running it on or at `http://localhost:8080`.