### PR TITLE
fix: prevent crash when _admin do not exists

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -357,6 +357,9 @@ const registerVerboseListeners = (
     );
 
     socket.conn.on("upgrade", (transport: any) => {
+      if (!socket.data._admin) {
+        socket.data._admin = {};
+      }
       socket.data._admin.transport = transport.name;
       adminNamespace.emit("socket_updated", {
         id: socket.id,


### PR DESCRIPTION
In some cases socket.io-admin package crashes, because of missing _admin trying to set 